### PR TITLE
Add support for empty image array input

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,17 +13,26 @@ var mapnik = require('mapnik'),
  */
 function generateLayout(imgs, pixelRatio, format) {
     assert(typeof pixelRatio === 'number' && Array.isArray(imgs));
+    var imagesWithSizes;
 
-    // calculate the size of each image and add to width, height props
-    var imagesWithSizes = imgs.map(function(img) {
-        var image = mapnik.Image.fromSVGBytesSync(img.svg, { scale: pixelRatio });
-        var buffer = image.encodeSync('png');
-        return xtend(img, {
-            width: image.width(),
-            height: image.height(),
-            buffer: buffer
+    if (!imgs.length) {
+        imagesWithSizes = [{
+            width: 1,
+            height: 1,
+            buffer: new mapnik.Image(1, 1).encodeSync('png')
+        }];
+    } else {
+        // calculate the size of each image and add to width, height props
+        imagesWithSizes = imgs.map(function(img) {
+            var image = mapnik.Image.fromSVGBytesSync(img.svg, { scale: pixelRatio });
+            var buffer = image.encodeSync('png');
+            return xtend(img, {
+                width: image.width(),
+                height: image.height(),
+                buffer: buffer
+            });
         });
-    });
+    }
 
     // bin-pack the images, adding x, y props
     var packing = pack(imagesWithSizes);

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,14 @@ test('generateLayout', function(t) {
     t.end();
 });
 
+test('generateLayout with empty array', function(t) {
+    var layout = spritezero.generateLayout([], 1);
+    t.equal(layout.items.length, 1);
+    t.equal(layout.height, 1);
+    t.equal(layout.width, 1);
+    t.end();
+});
+
 test('generateImage', function(t) {
     [1, 2, 4].forEach(function(scale) {
         t.test('@' + scale, function(tt) {


### PR DESCRIPTION
Implements: https://github.com/mapbox/spritezero/issues/11

This adds support for an empty array input and generates a 1x1 pixel image using `mapnik.Image()`. 

/cc @jfirebaugh @jakepruitt 