### PR TITLE
Allow for empty array input for generateImage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var mapnik = require('mapnik'),
     assert = require('assert'),
     xtend = require('xtend'),
-    pack = require('bin-pack');
+    pack = require('bin-pack'),
+    emptyPNG = new mapnik.Image(1, 1).encodeSync('png');
 
 /**
  * Pack a list of images with width and height into a sprite layout.
@@ -59,7 +60,7 @@ module.exports.generateLayout = generateLayout;
  */
 function generateImage(packing, callback) {
     assert(typeof packing === 'object' && typeof callback === 'function');
-    if (!packing.items.length) return new mapnik.Image(1, 1).encode('png', callback);
+    if (!packing.items.length) return callback(null, emptyPNG);
 
     mapnik.blend(packing.items, {
         width: packing.width,

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ module.exports.generateLayout = generateLayout;
  */
 function generateImage(packing, callback) {
     assert(typeof packing === 'object' && typeof callback === 'function');
+    if (!packing.items.length) return callback(null, new mapnik.Image(1, 1).encodeSync('png'));
 
     mapnik.blend(packing.items, {
         width: packing.width,

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports.generateLayout = generateLayout;
  */
 function generateImage(packing, callback) {
     assert(typeof packing === 'object' && typeof callback === 'function');
-    if (!packing.items.length) return callback(null, new mapnik.Image(1, 1).encodeSync('png'));
+    if (!packing.items.length) return new mapnik.Image(1, 1).encode('png', callback);
 
     mapnik.blend(packing.items, {
         width: packing.width,

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,11 @@ test('generateImage', function(t) {
     });
 });
 
+test('generateLayout with empty input', function(t) {
+    t.deepEqual(spritezero.generateLayout([], 1, true), {});
+    t.end();
+});
+
 test('generateImage with empty input', function(t) {
     var layout = spritezero.generateLayout([], 1);
     spritezero.generateImage(layout, function(err, sprite) {

--- a/test/test.js
+++ b/test/test.js
@@ -46,3 +46,13 @@ test('generateImage', function(t) {
         });
     });
 });
+
+test('generateImage with empty input', function(t) {
+    var layout = spritezero.generateLayout([], 1);
+    spritezero.generateImage(layout, function(err, sprite) {
+        t.notOk(err, 'no error');
+        t.ok(sprite, 'produces image');
+        t.equal(typeof sprite, 'object');
+        t.end();
+    });
+});


### PR DESCRIPTION
Implements: https://github.com/mapbox/spritezero/issues/11

This adds support for an empty array input and generates a 1x1 pixel image using `mapnik.Image()`. 

/cc @jfirebaugh @jakepruitt  @tmcw 