### PR TITLE
Use mapnik vtv2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "bin-pack": "^1.0.1",
-    "mapnik": "~3.4.14",
+    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/v2_spec",
     "queue-async": "^1.0.7",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Preparing for new version of mapnik that handles vector tile v2 spec. Shouldn't make any difference to spritezero, but it's worth prepping for.