### PR TITLE
Use a custom comparator over sort-by

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ var xtend = require('xtend');
 var ShelfPack = require('shelf-pack');
 var queue = require('queue-async');
 var emptyPNG = new mapnik.Image(1, 1).encodeSync('png');
-var sortBy = require('sort-by');
 
-var heightAscThanNameComparator = sortBy('-height', 'id');
+function heightAscThanNameComparator(a, b) {
+    return (b.height - a.height) || (a.id < b.id ? -1 : 1);
+};
 
 /**
  * Pack a list of images with width and height into a sprite layout.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "mapnik": "~3.5.0",
     "queue-async": "^1.0.7",
     "shelf-pack": "1.0.0",
-    "sort-by": "^1.1.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var test = require('tape'),
     fs = require('fs'),
     glob = require('glob'),
     path = require('path'),
+    queue = require('queue-async'),
     spritezero = require('../');
 
 var update = !!process.env.UPDATE;
@@ -24,6 +25,28 @@ test('generateLayout', function(t) {
         t.equal(layout.items.length, 360);
         t.equal(layout.items[0].x, 0);
         t.equal(layout.items[0].y, 0);
+        t.end();
+    });
+});
+
+test('generateLayout bench (concurrency=1,x10)', function(t) {
+    var start = +new Date();
+    var q = queue(1);
+    for (var i = 0; i < 10; i++) q.defer(spritezero.generateLayout, getFixtures(), 1, false);
+    q.awaitAll(function(err) {
+        t.ifError(err);
+        t.ok(true, (+new Date() - start) + 'ms');
+        t.end();
+    });
+});
+
+test('generateLayout bench (concurrency=4,x20)', function(t) {
+    var start = +new Date();
+    var q = queue(4);
+    for (var i = 0; i < 20; i++) q.defer(spritezero.generateLayout, getFixtures(), 1, false);
+    q.awaitAll(function(err) {
+        t.ifError(err);
+        t.ok(true, (+new Date() - start) + 'ms');
         t.end();
     });
 });


### PR DESCRIPTION
A little hand-timing shows that in `master` the time breakdown of `generateLayout` looks like this:

```
png: 120ms
sort: 196ms
pack: 4ms
```

The time for `svg => png` rasterization + encoding makes sense but :flushed: on the sort...

This branch

- Adds a basic benchmark for `generateLayout`
- Switches from `sort-by` to a custom comparator meant to do the same order comparison

**Before**

```
# generateLayout bench (concurrency=1,x10)
ok 5 null
ok 6 3001ms
# generateLayout bench (concurrency=4,x20)
ok 7 null
ok 8 5079ms
```

**After**

```
# generateLayout bench (concurrency=1,x10)
ok 5 null
ok 6 1478ms
# generateLayout bench (concurrency=4,x20)
ok 7 null
ok 8 2337ms
```

cc @jakepruitt @bhousel @ianshward 