### PR TITLE
Make sure heightAscThanNameComparator is transitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var queue = require('queue-async');
 var emptyPNG = new mapnik.Image(1, 1).encodeSync('png');
 
 function heightAscThanNameComparator(a, b) {
-    return (b.height - a.height) || (a.id < b.id ? -1 : 1);
+    return (b.height - a.height) || ((a.id === b.id) ? 0 : (a.id < b.id ? -1 : 1));
 };
 
 /**


### PR DESCRIPTION
Just a small preventive fix. `heightAscThanNameComparator` isn't transitive as implemented, it shouldn't happen but if a and b were the same object then this would likely result in undefined behavior because a > b is true but b > a is also true.