### PR TITLE
Pin mapnik to 3.5.13 since 3.5.14 introduces major new dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Tom MacWright",
   "license": "ISC",
   "dependencies": {
-    "mapnik": "~3.5.13",
+    "mapnik": "3.5.13",
     "queue-async": "^1.2.1",
     "shelf-pack": "2.0.1",
     "xtend": "^4.0.1",


### PR DESCRIPTION
@bhousel Proposing pinning node-mapnik to 3.5.13. 

Reason being, [3.5.14](https://github.com/mapnik/node-mapnik/blob/master/CHANGELOG.md) is somehow just a _patch_ version bump, but introduces _major_ changes to the toolchain requirements, which transitively propagates to the requirements for spritezero. (`gcc 5.x` amongst other things, which is something we're personally not ready to migrate to). I have opened a small [pull request](https://github.com/mapnik/node-mapnik/pull/698) with a comment on why this is just a patch bump on their end.

Suggest releasing 3.7.1 with pinned mapnik 3.5.13 and then anything >= 3.5.14 could be released as 3.8.x so that we don't have this ripple of major new dependencies in spritezero

Totally understandable if this isn't something you guys want, in which case we can just fork/pin the repo on our end. Just wanted to ping you guys beforehand.

Thanks!

