### PR TITLE
Bump mapnik to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "json-stable-stringify": "^1.0.1",
     "@mapbox/shelf-pack": "~3.0.0",
-    "mapnik": "~3.5.14",
+    "mapnik": "3.6.0",
     "queue-async": "^1.2.1",
     "xtend": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "json-stable-stringify": "^1.0.1",
     "@mapbox/shelf-pack": "~3.0.0",
-    "mapnik": "3.6.0",
+    "mapnik": "~3.6.0",
     "queue-async": "^1.2.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Not 100% sure, but I do not think any methods used in this library were updated in `v3.6.0`.

/cc @flippmoke 