### PR TITLE
Bump to 6.0.0, mapnik to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 :warning: = breaking change
+## 5.2.0
+##### 2018-02-22
+* Updates Mapnik depedency to 3.7.0
+
 ## 5.1.0
 ##### 2017-05-25
 * Added removeOversizedIcons boolean to the options args - if set to true, will filter out oversized icons from the response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 :warning: = breaking change
-## 5.2.0
+## 6.0.0
 ##### 2018-02-22
 * Updates Mapnik depedency to 3.7.0
+* Drops support for windows
 
 ## 5.1.0
 ##### 2017-05-25

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "main": "index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "main": "index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",
@@ -16,7 +16,7 @@
   "dependencies": {
     "json-stable-stringify": "^1.0.1",
     "@mapbox/shelf-pack": "~3.0.0",
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "queue-async": "^1.2.1",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Updates to version `6.0.0`, switches to use mapnik `3.7.0`. Drops support for windows