### PR TITLE
Fixes an extra end parenthesis in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var path = require('path');
     // suitable for exporting to a JSON sprite manifest file.
     spritezero.generateLayout({ imgs: svgs, pixelRatio: pxRatio, format: true }, function(err, dataLayout) {
         if (err) return;
-        fs.writeFileSync(jsonPath, JSON.stringify(dataLayout)));
+        fs.writeFileSync(jsonPath, JSON.stringify(dataLayout));
     });
 
     // Pass `false` in the layout parameter to generate an image layout


### PR DESCRIPTION
Extra end parenthesis in example caused an error when trying to run.