### PR TITLE
Produce an empty layout result for svg without width or height attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+##### 2019-11-08
+* Check if SVG has width/height attributes before encoding as image in `generateLayout` [#62](https://github.com/mapbox/spritezero/pull/69)
+
 ## 6.1.1
 ##### 2019-05-20
 * Check if SVG width/height are greater than zero before encoding as image in `generateLayout` [#62](https://github.com/mapbox/spritezero/pull/62)

--- a/index.js
+++ b/index.js
@@ -117,6 +117,8 @@ function generateLayoutInternal(options, callback) {
         }
         mapnik.Image.fromSVGBytes(img.svg, mapnikOpts, function(err, image) {
             if (err && err.message.match(/image created from svg must be \d+ pixels or fewer on each side/) && options.removeOversizedIcons) return callback(null, null);
+            // Produce a null result if no width or height attributes. The error message from mapnik has a typo "then"; account for potential future fix to "than".
+            if (err && err.message.match(/image created from svg must have a width and height greater (then|than) zero/)) return callback(null, null);
             if (err) return callback(err);
             if (!image.width() || !image.height()) return callback(null, null);
             image.encode('png', function(err, buffer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.1.1",
+  "version": "6.1.2-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2727,7 +2727,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2748,12 +2749,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2768,17 +2771,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2895,7 +2901,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2907,6 +2914,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2921,6 +2929,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2928,12 +2937,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2952,6 +2963,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3039,7 +3051,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3051,6 +3064,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3136,7 +3150,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3172,6 +3187,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3191,6 +3207,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3234,12 +3251,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4848,6 +4867,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6030,7 +6050,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.1.2-dev",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tap": "^10.1.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "docs": "documentation build index.js --lint --github --format html --output docs/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.1.1",
+  "version": "6.1.2-dev",
   "main": "index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.1.2-dev",
+  "version": "6.1.1",
   "main": "index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/test/fixture/no-width-or-height.svg
+++ b/test/fixture/no-width-or-height.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#00ff00"/>
+</svg>

--- a/test/test.js
+++ b/test/test.js
@@ -238,3 +238,42 @@ test('generateLayout only relative width/height SVG returns empty sprite object'
         });
     });
 });
+
+test('generateLayout containing image with no width or height SVG', function(t) {
+    var fixtures = [
+      {
+        id: 'no-width-or-height',
+        svg: fs.readFileSync('./test/fixture/no-width-or-height.svg')
+      },
+      {
+        id: 'art',
+        svg: fs.readFileSync('./test/fixture/svg/art-gallery-18.svg')
+      }
+    ];
+
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true }, function(err, formatted) {
+        t.ifError(err);
+        t.deepEqual(formatted, { art: { width: 18, height: 18, x: 0, y: 0, pixelRatio: 1 } }, 'only "art" is in layout');
+        t.end();
+    });
+});
+
+test('generateLayout containing only image with no width or height', function(t) {
+    var fixtures = [
+        {
+          id: 'no-width-or-height',
+          svg: fs.readFileSync('./test/fixture/no-width-or-height.svg')
+        }
+      ];
+
+      spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: false }, function(err, layout) {
+          t.ifError(err);
+          t.deepEqual(layout, { width: 1, height: 1, items: []}, 'empty layout');
+
+          spritezero.generateImage(layout, function(err, image) {
+              t.ifError(err);
+              t.deepEqual(image, emptyPNG, 'empty PNG response');
+              t.end();
+          });
+      });
+});


### PR DESCRIPTION
If an input SVG is missing `width` or `height` attributes, `mapnik.fromSVGBytes` will result in an error, which in turn makes `generateLayout` and `generateImage` fail.

This PR adds error-handling logic for this situation to instead callback with a `null` result, allowing the other layout sprite or image result to still be produced with the remaining "good" SVGs.

This is essentially an addendum to https://github.com/mapbox/spritezero/pull/62. 

cc @aparlato @samanpwbb 