### PR TITLE
Adds stretchMetadata option to generateLayout functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
     "extends": [
         "eslint:recommended"
     ],
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
     "rules": {
         "dot-notation": 2,
         "eqeqeq": [2, "smart"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 6.3.0
+#### 2020-04-10
+* Adds `stretchMetadata` option (defaults to true) to `generateLayout` and `generateLayoutUnique` [#75](https://github.com/mapbox/spritezero/pull/75)
+* Removes xtend as a direct dependency
+
 ## 6.2.0
 #### 2020-03-09
 * Add methods to parse and validate metadata for stretchable icons from SVGs: `extractMetadata` and `validateMetadata`
@@ -7,7 +12,7 @@
 
 ## 6.1.2
 ##### 2019-11-11
-* Check if SVG has width/height attributes before encoding as image in `generateLayout` [#62](https://github.com/mapbox/spritezero/pull/69)
+* Check if SVG has width/height attributes before encoding as image in `generateLayout` [#69](https://github.com/mapbox/spritezero/pull/69)
 
 ## 6.1.1
 ##### 2019-05-20

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Complete API documentation is here:  http://mapbox.github.io/spritezero/
 
 ### Installation
 
-Requires [nodejs](http://nodejs.org/) v4.0.0 or greater.
+Requires [nodejs](http://nodejs.org/) v10.0.0 or greater.
 
 ```bash
 $ npm install @mapbox/spritezero

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -25,7 +25,7 @@ function heightAscThanNameComparator(a, b) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`)
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
@@ -51,7 +51,7 @@ function generateLayout(options, callback) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`)
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
@@ -73,7 +73,7 @@ function generateLayoutUnique(options, callback) {
  * @param   {boolean}               [options.unique]               If true, deduplicate identical SVG images
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`)
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
@@ -138,9 +138,12 @@ function generateLayoutInternal(options, callback) {
 
             let q = new queue();
             q.defer(encodeImage, image);
-            if (options.stretchMetadata && img.svg.includes('mapbox-stretch')) {
+
+            // Stretch metadata only needs to be extracted for the data layout JSON (when options.format is true)
+            if (options.stretchMetadata && options.format && img.svg.includes('mapbox-stretch')) {
                 q.defer(extractMetadata, { svg: img.svg, pixelRatio: options.pixelRatio });
             }
+
             q.await((err, encodedImageProps, metadataProps) => {
                 if (err) return callback(err);
                 callback(null, {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -25,13 +25,14 @@ function heightAscThanNameComparator(a, b) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.stretchMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayout(options, callback) {
     options = options || {};
     options.unique = false;
+    options.stretchMetadata = options.stretchMetadata === undefined ? true : options.stretchMetadata;
     return generateLayoutInternal(options, callback);
 }
 
@@ -51,13 +52,14 @@ function generateLayout(options, callback) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.stretchMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayoutUnique(options, callback) {
     options = options || {};
     options.unique = true;
+    options.stretchMetadata = options.stretchMetadata === undefined ? true : options.stretchMetadata;
     return generateLayoutInternal(options, callback);
 }
 
@@ -73,7 +75,7 @@ function generateLayoutUnique(options, callback) {
  * @param   {boolean}               [options.unique]               If true, deduplicate identical SVG images
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.stretchMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -25,7 +25,7 @@ function heightAscThanNameComparator(a, b) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchY`, `stretchX`)
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`)
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
@@ -51,7 +51,7 @@ function generateLayout(options, callback) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchY`, `stretchX`)
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`)
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
@@ -73,7 +73,7 @@ function generateLayoutUnique(options, callback) {
  * @param   {boolean}               [options.unique]               If true, deduplicate identical SVG images
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchY`, `stretchX`)
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchX`, `stretchY`)
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,6 +1,5 @@
 var mapnik = require('mapnik');
 var assert = require('assert');
-var xtend = require('xtend');
 var ShelfPack = require('@mapbox/shelf-pack');
 var queue = require('queue-async');
 var extractMetadata = require('./extract-svg-metadata');
@@ -144,7 +143,11 @@ function generateLayoutInternal(options, callback) {
             }
             q.await((err, encodedImageProps, metadataProps) => {
                 if (err) return callback(err);
-                callback(null, xtend(img, encodedImageProps, metadataProps));
+                callback(null, {
+                    ...img,
+                    ...encodedImageProps,
+                    ...metadataProps
+                });
             });
         });
     }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,5 +1,6 @@
 var mapnik = require('mapnik');
 var assert = require('assert');
+var xtend = require('xtend');
 var ShelfPack = require('@mapbox/shelf-pack');
 var queue = require('queue-async');
 var extractMetadata = require('./extract-svg-metadata');
@@ -143,11 +144,7 @@ function generateLayoutInternal(options, callback) {
             }
             q.await((err, encodedImageProps, metadataProps) => {
                 if (err) return callback(err);
-                callback(null, {
-                    ...img,
-                    ...encodedImageProps,
-                    ...metadataProps
-                });
+                callback(null, xtend(img, encodedImageProps, metadataProps));
             });
         });
     }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,8 +1,8 @@
 var mapnik = require('mapnik');
 var assert = require('assert');
-var xtend = require('xtend');
 var ShelfPack = require('@mapbox/shelf-pack');
 var queue = require('queue-async');
+var extractMetadata = require('./extract-svg-metadata');
 var emptyPNG = new mapnik.Image(1, 1).encodeSync('png');
 
 module.exports.generateLayout = generateLayout;
@@ -20,13 +20,14 @@ function heightAscThanNameComparator(a, b) {
  * options object with the following keys:
  *
  * @param   {Object}                [options]
- * @param   {Object[]}              [options.imgs]        Array of `{ svg: Buffer, id: String }`
- * @param   {number}                [options.pixelRatio]  Ratio of a 72dpi screen pixel to the destination pixel density
- * @param   {boolean}               [options.format]      If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
- * @param   {boolean}               [options.maxIconSize] optional, overrides the max_size in mapnik
+ * @param   {Object[]}              [options.imgs]                 Array of `{ svg: Buffer, id: String }`
+ * @param   {number}                [options.pixelRatio]           Ratio of a 72dpi screen pixel to the destination pixel density
+ * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
+ * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {Function}              callback              Accepts two arguments, `err` and `layout` Object
- * @return  {DataLayout|ImgLayout}  layout                Generated Layout Object with sprite contents
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchY`, `stretchX`)
+ * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
+ * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayout(options, callback) {
     options = options || {};
@@ -45,13 +46,14 @@ function generateLayout(options, callback) {
  * options object with the following keys:
  *
  * @param   {Object}                [options]
- * @param   {Object[]}              [options.imgs]        Array of `{ svg: Buffer, id: String }`
- * @param   {number}                [options.pixelRatio]  Ratio of a 72dpi screen pixel to the destination pixel density
- * @param   {boolean}               [options.format]      If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
- * @param   {boolean}               [options.maxIconSize] optional, overrides the max_size in mapnik
+ * @param   {Object[]}              [options.imgs]                 Array of `{ svg: Buffer, id: String }`
+ * @param   {number}                [options.pixelRatio]           Ratio of a 72dpi screen pixel to the destination pixel density
+ * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
+ * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {Function}              callback              Accepts two arguments, `err` and `layout` Object
- * @return  {DataLayout|ImgLayout}  layout                Generated Layout Object with sprite contents
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchY`, `stretchX`)
+ * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
+ * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayoutUnique(options, callback) {
     options = options || {};
@@ -65,14 +67,15 @@ function generateLayoutUnique(options, callback) {
  *
  * @private
  * @param   {Object}                [options]
- * @param   {Object[]}              [options.imgs]        Array of `{ svg: Buffer, id: String }`
- * @param   {number}                [options.pixelRatio]  Ratio of a 72dpi screen pixel to the destination pixel density
- * @param   {boolean}               [options.format]      If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
- * @param   {boolean}               [options.unique]      If true, deduplicate identical SVG images
- * @param   {boolean}               [options.maxIconSize] optional, overrides the max_size in mapnik
+ * @param   {Object[]}              [options.imgs]                 Array of `{ svg: Buffer, id: String }`
+ * @param   {number}                [options.pixelRatio]           Ratio of a 72dpi screen pixel to the destination pixel density
+ * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
+ * @param   {boolean}               [options.unique]               If true, deduplicate identical SVG images
+ * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {Function}              callback            Accepts two arguments, `err` and `layout` Object
- * @return  {DataLayout|ImgLayout}  layout              Generated Layout Object with sprite contents
+ * @param   {boolean}               [options.stretchMetadata]      optional, if set, includes stretch metadata (`content`, `stretchY`, `stretchX`)
+ * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
+ * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayoutInternal(options, callback) {
     assert(typeof options.pixelRatio === 'number' && Array.isArray(options.imgs));
@@ -91,7 +94,7 @@ function generateLayoutInternal(options, callback) {
         /* The items for each SVG signature */
         var itemIdsPerSvg = {};
 
-        options.imgs.forEach(function(item) {
+        options.imgs.forEach((item) => {
             var svg = item.svg.toString('base64');
 
             svgPerItemId[item.id] = svg;
@@ -104,47 +107,62 @@ function generateLayoutInternal(options, callback) {
         });
 
         /* Only keep 1 item per svg signature for packing */
-        options.imgs = options.imgs.filter(function(item) {
+        options.imgs = options.imgs.filter((item) => {
             var svg = svgPerItemId[item.id];
             return item.id === itemIdsPerSvg[svg][0];
         });
     }
 
-    function createImagesWithSize(img, callback) {
+    function encodeImage(image, callback) {
+        image.encode('png', (err, buffer) => {
+            if (err) return callback(err);
+            callback(null, {
+                width: image.width(),
+                height: image.height(),
+                buffer
+            });
+        });
+    }
+
+    function createImages(img, callback) {
         var mapnikOpts = { scale: options.pixelRatio };
         if (options.maxIconSize) {
             mapnikOpts.max_size = options.maxIconSize;
         }
-        mapnik.Image.fromSVGBytes(img.svg, mapnikOpts, function(err, image) {
+        mapnik.Image.fromSVGBytes(img.svg, mapnikOpts, (err, image) => {
             if (err && err.message.match(/image created from svg must be \d+ pixels or fewer on each side/) && options.removeOversizedIcons) return callback(null, null);
             // Produce a null result if no width or height attributes. The error message from mapnik has a typo "then"; account for potential future fix to "than".
             if (err && err.message.match(/image created from svg must have a width and height greater (then|than) zero/)) return callback(null, null);
             if (err) return callback(err);
             if (!image.width() || !image.height()) return callback(null, null);
-            image.encode('png', function(err, buffer) {
+
+            let q = new queue();
+            q.defer(encodeImage, image);
+            if (options.stretchMetadata && img.svg.includes('mapbox-stretch')) {
+                q.defer(extractMetadata, { svg: img.svg, pixelRatio: options.pixelRatio });
+            }
+            q.await((err, encodedImageProps, metadataProps) => {
                 if (err) return callback(err);
-                callback(null, xtend(img, {
-                    width: image.width(),
-                    height: image.height(),
-                    buffer: buffer
-                }));
+                callback(null, {
+                    ...img,
+                    ...encodedImageProps,
+                    ...metadataProps
+                });
             });
         });
     }
 
     var q = new queue();
 
-    options.imgs.forEach(function(img) {
-        q.defer(createImagesWithSize, img);
+    options.imgs.forEach((img) => {
+        q.defer(createImages, img);
     });
 
-    q.awaitAll(function(err, imagesWithSizes){
+    q.awaitAll((err, imagesWithSizes) => {
         if (err) return callback(err);
 
         // remove nulls that get introduced if removeOversizedIcons is true
-        imagesWithSizes = imagesWithSizes.filter(function(img) {
-          return img;
-        });
+        imagesWithSizes = imagesWithSizes.filter((img) => img);
 
         imagesWithSizes.sort(heightAscThanNameComparator);
 
@@ -153,13 +171,13 @@ function generateLayoutInternal(options, callback) {
 
         if (options.format) {
             var obj = {};
-            imagesWithSizes.forEach(function(item) {
+            imagesWithSizes.forEach((item) => {
                 var itemIdsToUpdate = [item.id];
                 if (options.unique) {
                     var svg = svgPerItemId[item.id];
                     itemIdsToUpdate = itemIdsPerSvg[svg];
                 }
-                itemIdsToUpdate.forEach(function(itemIdToUpdate) {
+                itemIdsToUpdate.forEach((itemIdToUpdate) => {
                     obj[itemIdToUpdate] = {
                         width: item.width,
                         height: item.height,
@@ -167,6 +185,10 @@ function generateLayoutInternal(options, callback) {
                         y: item.y,
                         pixelRatio: options.pixelRatio
                     };
+
+                    if (item.content) { obj[itemIdToUpdate].content = item.content; }
+                    if (item.stretchX) { obj[itemIdToUpdate].stretchX = item.stretchX; }
+                    if (item.stretchY) { obj[itemIdToUpdate].stretchY = item.stretchY; }
                 });
             });
             return callback(null, obj);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.3.0-dev1",
+  "version": "6.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.2.0",
+  "version": "6.3.0-dev1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10425,7 +10425,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10425,8 +10425,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "mapnik": "^4.4.0",
     "queue-async": "^1.2.1",
     "svg-boundings": "^2.0.3",
-    "svgo": "^1.3.0",
-    "xtend": "^4.0.1"
+    "svgo": "^1.3.0"
   },
   "devDependencies": {
     "documentation": "4.0.0-beta10",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "mapnik": "^4.4.0",
     "queue-async": "^1.2.1",
     "svg-boundings": "^2.0.3",
-    "svgo": "^1.3.0"
+    "svgo": "^1.3.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "documentation": "4.0.0-beta10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.3.0-dev1",
+  "version": "6.3.0",
   "main": "./index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.3.0-dev",
+  "version": "6.3.0-dev1",
   "main": "./index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.2.0",
+  "version": "6.3.0-dev",
   "main": "./index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -278,7 +278,7 @@ test('generateLayout containing only image with no width or height', function(t)
       });
 });
 
-test('generateLayout with stretchMetadata option set to true', function (t) {
+test('generateLayout with stretchMetadata option set to false', function (t) {
     var fixtures = [
         {
             id: 'cn',
@@ -286,14 +286,14 @@ test('generateLayout with stretchMetadata option set to true', function (t) {
         }
     ];
 
-    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true, stretchMetadata: true }, function (err, formatted) {
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true, stretchMetadata: false }, function (err, formatted) {
         t.ifError(err);
-        t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1, content: [2, 5, 18, 18], stretchX: [[4, 16]], stretchY: [[5, 16]] } });
+        t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1 } });
         t.end();
     });
 });
 
-test('generateLayout without stretchMetadata option set', function (t) {
+test('generateLayout without stretchMetadata option set (defaults to true)', function (t) {
     var fixtures = [
         {
             id: 'cn',
@@ -303,12 +303,12 @@ test('generateLayout without stretchMetadata option set', function (t) {
 
     spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true }, function (err, formatted) {
         t.ifError(err);
-        t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1 } });
+        t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1, content: [2, 5, 18, 18], stretchX: [[4, 16]], stretchY: [[5, 16]] } });
         t.end();
     });
 });
 
-test('generateLayout with stretchMetadata option set to true and format set to false', function (t) {
+test('generateLayout without stretchMetadata option set (defaults to true) when generating an image layout (format set to false)', function (t) {
     var fixtures = [
         {
             id: 'cn',
@@ -316,7 +316,7 @@ test('generateLayout with stretchMetadata option set to true and format set to f
         }
     ];
 
-    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: false, stretchMetadata: true }, function (err, formatted) {
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: false }, function (err, formatted) {
         t.ifError(err);
         t.equal(formatted.items[0].stretchX, undefined);
         t.end();

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -277,3 +277,48 @@ test('generateLayout containing only image with no width or height', function(t)
           });
       });
 });
+
+test('generateLayout with stretchMetadata option set to true', function (t) {
+    var fixtures = [
+        {
+            id: 'cn',
+            svg: fs.readFileSync('./test/fixture/svg-metadata/cn-nths-expy-2-affinity.svg')
+        }
+    ];
+
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true, stretchMetadata: true }, function (err, formatted) {
+        t.ifError(err);
+        t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1, content: [2, 5, 18, 18], stretchX: [[4, 16]], stretchY: [[5, 16]] } });
+        t.end();
+    });
+});
+
+test('generateLayout without stretchMetadata option set', function (t) {
+    var fixtures = [
+        {
+            id: 'cn',
+            svg: fs.readFileSync('./test/fixture/svg-metadata/cn-nths-expy-2-affinity.svg')
+        }
+    ];
+
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true }, function (err, formatted) {
+        t.ifError(err);
+        t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1 } });
+        t.end();
+    });
+});
+
+test('generateLayout with stretchMetadata option set to true and format set to false', function (t) {
+    var fixtures = [
+        {
+            id: 'cn',
+            svg: fs.readFileSync('./test/fixture/svg-metadata/cn-nths-expy-2-affinity.svg')
+        }
+    ];
+
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: false, stretchMetadata: true }, function (err, formatted) {
+        t.ifError(err);
+        t.equal(formatted.items[0].stretchX, undefined);
+        t.end();
+    });
+});


### PR DESCRIPTION
Adds `stretchMetadata` as an optional option to `generateLayout` and `generateLayoutUnique`. If set to `true`, the resulting layout object will contain the following stretch metadata properties, if present: `content`, `stretchX`, and `stretchY`.

This leverages work from https://github.com/mapbox/spritezero/pull/68.

- [ ] Is there any reason we should make the default instead be to include stretch metadata, if present? (As opposed to the default being not to include it in the layout object.)

TODO:

- [x] Add unit tests