### PR TITLE
Optimize layout and image generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 language: node_js
-sudo: false
+
 node_js:
-  - '10'
-  - '12'
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+  - 10
+  - 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 7.0.0
+#### 2020-04-22
+* Optimized layout and image generation: 1.5x faster `generateLayout`
+
 ## 6.3.0
 #### 2020-04-10
 * Adds `stretchMetadata` option (defaults to true) to `generateLayout` and `generateLayoutUnique` [#75](https://github.com/mapbox/spritezero/pull/75)

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -127,8 +127,7 @@ function generateLayoutInternal(options, callback) {
             if (err) return callback(err);
             if (!image.width() || !image.height()) return callback(null, null);
 
-            // For the data layout JSON (when options.format is true)
-            // - We need to extract stretch metadata
+            // For the data layout JSON (when options.format is true), extract stretch metadata if present
             if (options.stretchMetadata && options.format && img.svg.includes('mapbox-stretch')) {
                 const metaOps = { svg: img.svg, pixelRatio: options.pixelRatio };
                 extractMetadata(metaOps, (err, metadataProps) => {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -115,17 +115,6 @@ function generateLayoutInternal(options, callback) {
         });
     }
 
-    function encodeImage(image, callback) {
-        image.encode('png', (err, buffer) => {
-            if (err) return callback(err);
-            callback(null, {
-                width: image.width(),
-                height: image.height(),
-                buffer
-            });
-        });
-    }
-
     function createImages(img, callback) {
         var mapnikOpts = { scale: options.pixelRatio };
         if (options.maxIconSize) {
@@ -138,22 +127,38 @@ function generateLayoutInternal(options, callback) {
             if (err) return callback(err);
             if (!image.width() || !image.height()) return callback(null, null);
 
-            let q = new queue();
-            q.defer(encodeImage, image);
-
-            // Stretch metadata only needs to be extracted for the data layout JSON (when options.format is true)
-            if (options.stretchMetadata && options.format && img.svg.includes('mapbox-stretch')) {
-                q.defer(extractMetadata, { svg: img.svg, pixelRatio: options.pixelRatio });
-            }
-
-            q.await((err, encodedImageProps, metadataProps) => {
-                if (err) return callback(err);
-                callback(null, {
+            if (options.format) {
+              // For the data layout JSON (when options.format is true)
+              // - We need to extract stretch metadata
+              // - We don't need to encode the image
+              if (options.stretchMetadata && img.svg.includes('mapbox-stretch')) {
+                  const metaOps = { svg: img.svg, pixelRatio: options.pixelRatio };
+                  extractMetadata(metaOps, (err, metadataProps) => {
+                      return callback(err, {
+                        ...img,
+                        width: image.width(),
+                        height: image.height(),
+                        ...metadataProps
+                      });
+                  });
+              } else {
+                  return callback(null, {
                     ...img,
-                    ...encodedImageProps,
-                    ...metadataProps
-                });
-            });
+                    width: image.width(),
+                    height: image.height()
+                  });
+              }
+            } else {
+              // For the image layout (when options.format is undefined)
+              // - We don't need to extract stretch metadata
+              // - We need to encode the image
+              return callback(err, {
+                  ...img,
+                  width: image.width(),
+                  height: image.height(),
+                  buffer: image
+              });
+            }
         });
     }
 
@@ -219,7 +224,6 @@ function generateLayoutInternal(options, callback) {
 function generateImage(layout, callback) {
     assert(typeof layout === 'object' && typeof callback === 'function');
     if (!layout.items.length) return callback(null, emptyPNG);
-
     mapnik.blend(layout.items, {
         width: layout.width,
         height: layout.height

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -127,37 +127,25 @@ function generateLayoutInternal(options, callback) {
             if (err) return callback(err);
             if (!image.width() || !image.height()) return callback(null, null);
 
-            if (options.format) {
-              // For the data layout JSON (when options.format is true)
-              // - We need to extract stretch metadata
-              // - We don't need to encode the image
-              if (options.stretchMetadata && img.svg.includes('mapbox-stretch')) {
-                  const metaOps = { svg: img.svg, pixelRatio: options.pixelRatio };
-                  extractMetadata(metaOps, (err, metadataProps) => {
-                      return callback(err, {
-                        ...img,
-                        width: image.width(),
-                        height: image.height(),
-                        ...metadataProps
-                      });
-                  });
-              } else {
-                  return callback(null, {
-                    ...img,
-                    width: image.width(),
-                    height: image.height()
-                  });
-              }
+            // For the data layout JSON (when options.format is true)
+            // - We need to extract stretch metadata
+            if (options.stretchMetadata && options.format && img.svg.includes('mapbox-stretch')) {
+                const metaOps = { svg: img.svg, pixelRatio: options.pixelRatio };
+                extractMetadata(metaOps, (err, metadataProps) => {
+                    return callback(err, {
+                      ...img,
+                      width: image.width(),
+                      height: image.height(),
+                      ...metadataProps
+                    });
+                });
             } else {
-              // For the image layout (when options.format is undefined)
-              // - We don't need to extract stretch metadata
-              // - We need to encode the image
-              return callback(err, {
+                return callback(null, {
                   ...img,
                   width: image.width(),
                   height: image.height(),
                   buffer: image
-              });
+                });
             }
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,44 +1,9 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.3.0",
+  "version": "7.0.0-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@greenkeeper/flags": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@greenkeeper/flags/-/flags-3.0.1.tgz",
-      "integrity": "sha1-N7of8sdiohFCvX6oxmzjTbP0zAk=",
-      "dev": true,
-      "requires": {
-        "@greenkeeper/rc": "^2.0.0",
-        "lodash": "^4.11.1",
-        "nerf-dart": "^1.0.0",
-        "nopt": "^3.0.6"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        }
-      }
-    },
-    "@greenkeeper/rc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@greenkeeper/rc/-/rc-2.0.1.tgz",
-      "integrity": "sha1-Ruh7aU/hSEEAWrZSGlo5sIMK+IE=",
-      "dev": true,
-      "requires": {
-        "env-paths": "^1.0.0",
-        "lodash": "^4.11.1",
-        "mkdirp": "^0.5.1",
-        "os-homedir": "^1.0.1"
-      }
-    },
     "@mapbox/shelf-pack": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.0.0.tgz",
@@ -261,12 +226,6 @@
       "requires": {
         "unherit": "^1.0.0"
       }
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
@@ -1510,12 +1469,6 @@
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
     "ccount": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
@@ -2387,12 +2340,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
     },
-    "env-paths": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
-      "dev": true
-    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2726,18 +2673,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2850,17 +2785,6 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3713,22 +3637,6 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
-    "greenkeeper-postpublish": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/greenkeeper-postpublish/-/greenkeeper-postpublish-1.4.0.tgz",
-      "integrity": "sha512-zxixseeCJK1NA/DzQtd5gXKxiQpCfBwZLSlIX8tkTOx0dygd4befAnQ4LGGB3IZn1eICC1RS5yNHMUM9qLOd+g==",
-      "dev": true,
-      "requires": {
-        "@greenkeeper/flags": "^3.0.0",
-        "hide-secrets": "^1.1.0",
-        "lodash": "^4.14.1",
-        "node-emoji": "^1.3.1",
-        "nopt": "^4.0.1",
-        "npmlog": "^4.0.0",
-        "os-homedir": "^1.0.1",
-        "request": "^2.88.0"
-      }
-    },
     "gulp-sourcemaps": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
@@ -3740,36 +3648,6 @@
         "strip-bom": "^2.0.0",
         "through2": "^2.0.0",
         "vinyl": "^1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        }
       }
     },
     "has": {
@@ -3876,15 +3754,6 @@
         "sntp": "1.x.x"
       }
     },
-    "hide-secrets": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hide-secrets/-/hide-secrets-1.1.0.tgz",
-      "integrity": "sha1-JAZoCU1cu+ZkAr4/rOMRwM7PrMI=",
-      "dev": true,
-      "requires": {
-        "traverse": "^0.6.6"
-      }
-    },
     "highlight.js": {
       "version": "9.15.6",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
@@ -3928,17 +3797,6 @@
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
       "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
       "dev": true
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -4409,12 +4267,6 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -4548,12 +4400,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
     "log-driver": {
@@ -4937,26 +4783,11 @@
         "sax": "^1.2.4"
       }
     },
-    "nerf-dart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
-      "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
-      "dev": true
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
-    },
-    "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-      "dev": true,
-      "requires": {
-        "lodash.toarray": "^4.4.0"
-      }
     },
     "node-pre-gyp": {
       "version": "0.13.0",
@@ -7713,12 +7544,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8073,12 +7898,6 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8166,18 +7985,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-      "dev": true
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "q": {
@@ -8856,42 +8663,6 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        }
-      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -9849,30 +9620,6 @@
         "vfile": "^1.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -9908,15 +9655,6 @@
       "resolved": "https://registry.npmjs.org/tsame/-/tsame-1.1.2.tgz",
       "integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -10160,15 +9898,6 @@
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
-      }
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "urix": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "7.0.0-dev.1",
+  "version": "7.0.0",
   "main": "./index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "documentation": "4.0.0-beta10",
     "eslint": "^3.9.0",
     "glob": "^7.1.0",
-    "greenkeeper-postpublish": "^1.0.1",
     "tap": "^10.1.0"
   },
   "engines": {
@@ -35,7 +34,6 @@
     "docs": "documentation build lib --lint --github --format html --output docs/",
     "lint": "eslint lib/ test/",
     "regenerate-fixtures": "node test/regenerate.js",
-    "test": "npm run lint && tap --cov test/*.test.js",
-    "postpublish": "greenkeeper-postpublish"
+    "test": "npm run lint && tap --cov test/*.test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "6.3.0",
+  "version": "7.0.0-dev.1",
   "main": "./index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -11,16 +11,17 @@ var test = require('tap').test,
 var update = process.env.UPDATE;
 var emptyPNG = new mapnik.Image(1, 1).encodeSync('png');
 
+const fixtures = glob.sync(path.resolve(path.join(__dirname, '/fixture/svg/*.svg'))).map(function(im) {
+    return {
+        svg: fs.readFileSync(im),
+        id: path.basename(im).replace('.svg', '')
+    };
+});
+
 function getFixtures() {
-    return glob.sync(path.resolve(path.join(__dirname, '/fixture/svg/*.svg')))
-        .map(function(im) {
-            return {
-                svg: fs.readFileSync(im),
-                id: path.basename(im).replace('.svg', '')
-            };
-        }).sort(function() {
-            return Math.random() - 0.5;
-        });
+    return fixtures.sort(function() {
+        return Math.random() - 0.5;
+    });
 }
 
 test('generateLayout', function(t) {


### PR DESCRIPTION
Spritezero has some inefficiencies in the image handling code. This fixes the problems.

Previously:

 - Images were encoded to PNG format in `generateLayout`, only to be then decoded again in `generateImage` (so the encoding served no purpose). PNG encoding is known to be expensive (since it involves memory allocations and gzip compression).
 - Images were encoded to png format in `generateLayout` even when the underlying image was never needed. When `options.format` was present, denoting only a data layout, then the only thing needed from the image was the width and height (and not the encoded buffer).

Now:

 - Images are no longer encoded. Instead the `mapnik.Image` instance is passed along to `generateImages`. That function uses `mapnik.blend` which supports passing `mapnik.Image` objects directly since https://github.com/mapnik/node-mapnik/pull/905.
 - The code inside `generateLayout` is simplified to avoid needing an async queue

This closes https://github.com/mapbox/spritezero/issues/7

/cc @mapbox/static-apis @mapbox/map-design-api 