### PR TITLE
Use `main`  branch as default, migrate to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![npm version](https://badge.fury.io/js/%40mapbox%2Fspritezero.svg)](https://badge.fury.io/js/%40mapbox%2Fspritezero)
-[![build status](https://secure.travis-ci.org/mapbox/spritezero.svg)](http://travis-ci.org/mapbox/spritezero)
+[![Build Status](https://travis-ci.com/mapbox/spritezero.svg?branch=main)](https://travis-ci.com/mapbox/spritezero)
 
 ## spritezero
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 ## Release Checklist
 
 #### Update version, docs, tag, and publish
-- [ ] git checkout master
+- [ ] git checkout main
 - [ ] npm install
 - [ ] npm run test
 - [ ] Update CHANGELOG
@@ -10,5 +10,5 @@
 - [ ] git add .
 - [ ] git commit -m 'vA.B.C'
 - [ ] git tag vA.B.C
-- [ ] git push origin master vA.B.C
+- [ ] git push origin main vA.B.C
 - [ ] npm publish


### PR DESCRIPTION
- Update docs to refer to `main` branch. I've already updated the repository settings in GitHub to make `main` the default.
- Switch Travis badge to use `travis-ci.com`. This repo has been migrated from `travis-ci.org` already: https://travis-ci.com/github/mapbox/spritezero