### PR TITLE
Extract text placeholder paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2021-08-23
+* Changes the `stretchMetadata` option to `extractMetadata`.
+* Extends the `extractMetadata` function to support placeholder text elements.
 
 ## 7.0.1
 * `generateLayout({format:true})` now returns a second argument, which is a layout object that can be sent to generateImage to generate a final image. Normally users would generate this object with `generateLayout({format:false})` but now `generateLayout({format:true})` will provide both the data layout (as first arg) and the image layout (as the second arg).

--- a/lib/extract-svg-metadata.js
+++ b/lib/extract-svg-metadata.js
@@ -78,7 +78,7 @@ const extractMapboxMetadata = {
                 (info.metadata.stretchX = info.metadata.stretchX || []).push([bounds.left, bounds.right]);
                 (info.metadata.stretchY = info.metadata.stretchY || []).push([bounds.top, bounds.bottom]);
             } else if (metadata.value === 'content' || metadata.value === 'text-placeholder') {
-                info.metadata.content = [bounds.left, bounds.top, bounds.right, bounds.bottom];
+                info.metadata[metadata.value] = [bounds.left, bounds.top, bounds.right, bounds.bottom];
             }
         }
 

--- a/lib/extract-svg-metadata.js
+++ b/lib/extract-svg-metadata.js
@@ -77,7 +77,7 @@ const extractMapboxMetadata = {
             } else if (metadata.value === 'stretch') {
                 (info.metadata.stretchX = info.metadata.stretchX || []).push([bounds.left, bounds.right]);
                 (info.metadata.stretchY = info.metadata.stretchY || []).push([bounds.top, bounds.bottom]);
-            } else if (metadata.value === 'content') {
+            } else if (metadata.value === 'content' || metadata.value === 'text-placeholder') {
                 info.metadata.content = [bounds.left, bounds.top, bounds.right, bounds.bottom];
             }
         }

--- a/lib/extract-svg-metadata.js
+++ b/lib/extract-svg-metadata.js
@@ -78,7 +78,8 @@ const extractMapboxMetadata = {
                 (info.metadata.stretchX = info.metadata.stretchX || []).push([bounds.left, bounds.right]);
                 (info.metadata.stretchY = info.metadata.stretchY || []).push([bounds.top, bounds.bottom]);
             } else if (metadata.value === 'content' || metadata.value === 'text-placeholder') {
-                info.metadata.content = [bounds.left, bounds.top, bounds.right, bounds.bottom];
+                const key = metadata.value === 'content' ? 'content' : 'placeholder';
+                info.metadata[key] = [bounds.left, bounds.top, bounds.right, bounds.bottom];
             }
         }
 

--- a/lib/extract-svg-metadata.js
+++ b/lib/extract-svg-metadata.js
@@ -78,7 +78,7 @@ const extractMapboxMetadata = {
                 (info.metadata.stretchX = info.metadata.stretchX || []).push([bounds.left, bounds.right]);
                 (info.metadata.stretchY = info.metadata.stretchY || []).push([bounds.top, bounds.bottom]);
             } else if (metadata.value === 'content' || metadata.value === 'text-placeholder') {
-                info.metadata[metadata.value] = [bounds.left, bounds.top, bounds.right, bounds.bottom];
+                info.metadata.content = [bounds.left, bounds.top, bounds.right, bounds.bottom];
             }
         }
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -195,9 +195,9 @@ function generateLayoutInternal(options, callback) {
                         pixelRatio: options.pixelRatio
                     };
 
-                    if (item.content) { dataLayout[itemIdToUpdate].content = item.content; }
-                    if (item.stretchX) { dataLayout[itemIdToUpdate].stretchX = item.stretchX; }
-                    if (item.stretchY) { dataLayout[itemIdToUpdate].stretchY = item.stretchY; }
+                    ['content', 'placeholder', 'stretchX', 'stretchY'].forEach(key => {
+                        if (item[key]) { dataLayout[itemIdToUpdate][key] = item[key]; }
+                    });
                 });
             });
             return callback(null, dataLayout, imageLayout);

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -26,7 +26,7 @@ function heightAscThanNameComparator(a, b) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch and placeholder metadata (`content`, `stretchX`, `stretchY`, `placeholder`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -53,7 +53,7 @@ function generateLayout(options, callback) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout} as first argument to callback and {@link ImgLayout} as the second argument; if false, generate only {@link ImgLayout} as the first argument to the callback function
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch and placeholder metadata (`content`, `stretchX`, `stretchY`, `placeholder`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -198,7 +198,6 @@ function generateLayoutInternal(options, callback) {
                     if (item.content) { dataLayout[itemIdToUpdate].content = item.content; }
                     if (item.stretchX) { dataLayout[itemIdToUpdate].stretchX = item.stretchX; }
                     if (item.stretchY) { dataLayout[itemIdToUpdate].stretchY = item.stretchY; }
-                    if (item.placeholder) { dataLayout[itemIdToUpdate].placeholder = item.placeholder; }
                 });
             });
             return callback(null, dataLayout, imageLayout);

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -128,8 +128,12 @@ function generateLayoutInternal(options, callback) {
             if (err) return callback(err);
             if (!image.width() || !image.height()) return callback(null, null);
 
-            // For the data layout JSON (when options.format is true), extract stretch metadata if present
-            if (options.stretchMetadata && options.format && img.svg.includes('mapbox-stretch')) {
+            // For the data layout JSON (when options.format is true), extract stretch and placeholder metadata if present
+            if (
+                options.stretchMetadata &&
+                options.format &&
+                (img.svg.includes('mapbox-stretch') || img.svg.includes('mapbox-text-placeholder'))
+            ) {
                 const metaOps = { svg: img.svg, pixelRatio: options.pixelRatio };
                 extractMetadata(metaOps, (err, metadataProps) => {
                     return callback(err, {
@@ -194,6 +198,7 @@ function generateLayoutInternal(options, callback) {
                     if (item.content) { dataLayout[itemIdToUpdate].content = item.content; }
                     if (item.stretchX) { dataLayout[itemIdToUpdate].stretchX = item.stretchX; }
                     if (item.stretchY) { dataLayout[itemIdToUpdate].stretchY = item.stretchY; }
+                    if (item.placeholder) { dataLayout[itemIdToUpdate].placeholder = item.placeholder; }
                 });
             });
             return callback(null, dataLayout, imageLayout);

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -26,14 +26,14 @@ function heightAscThanNameComparator(a, b) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout}; if false, generate {@link ImgLayout}
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayout(options, callback) {
     options = options || {};
     options.unique = false;
-    options.stretchMetadata = options.stretchMetadata === undefined ? true : options.stretchMetadata;
+    options.extractMetadata = options.extractMetadata === undefined ? true : options.extractMetadata;
     return generateLayoutInternal(options, callback);
 }
 
@@ -53,14 +53,14 @@ function generateLayout(options, callback) {
  * @param   {boolean}               [options.format]               If true, generate {@link DataLayout} as first argument to callback and {@link ImgLayout} as the second argument; if false, generate only {@link ImgLayout} as the first argument to the callback function
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
 function generateLayoutUnique(options, callback) {
     options = options || {};
     options.unique = true;
-    options.stretchMetadata = options.stretchMetadata === undefined ? true : options.stretchMetadata;
+    options.extractMetadata = options.extractMetadata === undefined ? true : options.extractMetadata;
     return generateLayoutInternal(options, callback);
 }
 
@@ -76,7 +76,7 @@ function generateLayoutUnique(options, callback) {
  * @param   {boolean}               [options.unique]               If true, deduplicate identical SVG images
  * @param   {boolean}               [options.maxIconSize]          optional, overrides the max_size in mapnik
  * @param   {boolean}               [options.removeOversizedIcons] optional, if set, filters out icons that mapnik says are too big
- * @param   {boolean}               [options.stretchMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
+ * @param   {boolean}               [options.extractMetadata]      optional, defaults to true; if set to false, omits stretch metadata (`content`, `stretchX`, `stretchY`) in {@link DataLayout}
  * @param   {Function}              callback                       Accepts two arguments, `err` and `layout` Object
  * @return  {DataLayout|ImgLayout}  layout                         Generated Layout Object with sprite contents
  */
@@ -130,7 +130,7 @@ function generateLayoutInternal(options, callback) {
 
             // For the data layout JSON (when options.format is true), extract stretch and placeholder metadata if present
             if (
-                options.stretchMetadata &&
+                options.extractMetadata &&
                 options.format &&
                 (img.svg.includes('mapbox-stretch') || img.svg.includes('mapbox-text-placeholder'))
             ) {

--- a/test/fixture/svg-metadata/au-national-route-5.svg
+++ b/test/fixture/svg-metadata/au-national-route-5.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" id="au-national-route-5" width="38" height="20" viewBox="0 0 38 20">
+  <g>
+    <path d="M0,0 H38 V20 H0 Z" fill="none"/>
+    <path d="M1,3V13a2.951,2.951,0,0,0,2,3c1.632.744,16,3,16,3s14.368-2.256,16-3a2.951,2.951,0,0,0,2-3V3Z" fill="none" stroke="#222222" stroke-linejoin="round" stroke-miterlimit="4px" stroke-width="2"/>
+    <path id="mapbox-stretch-x-1" d="M5,5l2,0" style="fill:none;"/>
+    <rect id="mapbox-content" x="3" y="7" width="20" height="11" style="fill:none;"/>
+    <path id="mapbox-text-placeholder" d="M0,7 H38 V13 H0 Z" fill="none"/>
+    <path d="M1,3V13a2.951,2.951,0,0,0,2,3c1.632.744,16,3,16,3s14.368-2.256,16-3a2.951,2.951,0,0,0,2-3V3Z" fill="#ffffff"/>
+  </g>
+</svg>

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -301,7 +301,7 @@ test('generateLayout containing only image with no width or height', function(t)
       });
 });
 
-test('generateLayout with stretchMetadata option set to false', function (t) {
+test('generateLayout with extractMetadata option set to false', function (t) {
     var fixtures = [
         {
             id: 'cn',
@@ -309,14 +309,14 @@ test('generateLayout with stretchMetadata option set to false', function (t) {
         }
     ];
 
-    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true, stretchMetadata: false }, function (err, formatted) {
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true, extractMetadata: false }, function (err, formatted) {
         t.ifError(err);
         t.deepEqual(formatted, { cn: { width: 20, height: 23, x: 0, y: 0, pixelRatio: 1 } });
         t.end();
     });
 });
 
-test('generateLayout without stretchMetadata option set (defaults to true)', function (t) {
+test('generateLayout without extractMetadata option set (defaults to true)', function (t) {
     var fixtures = [
         {
             id: 'cn',
@@ -331,7 +331,7 @@ test('generateLayout without stretchMetadata option set (defaults to true)', fun
     });
 });
 
-test('generateLayout without stretchMetadata option set (defaults to true) when generating an image layout (format set to false)', function (t) {
+test('generateLayout without extractMetadata option set (defaults to true) when generating an image layout (format set to false)', function (t) {
     var fixtures = [
         {
             id: 'cn',

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -345,3 +345,31 @@ test('generateLayout without extractMetadata option set (defaults to true) when 
         t.end();
     });
 });
+
+test('generateLayout with both placeholder and stretch zone', function (t) {
+    var fixtures = [
+        {
+            id: 'au-national-route-5',
+            svg: fs.readFileSync('./test/fixture/svg-metadata/au-national-route-5.svg')
+        }
+    ];
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true }, function (err, formatted) {
+        t.ifError(err);
+        t.deepEqual(
+            formatted,
+            {
+                'au-national-route-5': {
+                    width: 38,
+                    height: 20,
+                    x: 0,
+                    y: 0,
+                    pixelRatio: 1,
+                    content: [3, 7, 23, 18],
+                    stretchX: [[5, 7]],
+                    placeholder: [0, 7, 38, 13]
+                }
+            }
+        );
+        t.end();
+    });
+});


### PR DESCRIPTION
This adds support for the `mapbox-text-placeholder` ID, which acts like `mapbox-content` and supports client-side compositing for highway shield icons. Closes #90 

Note that this changes the `stretchMetadata` option to `extractMetadata`.

- [x] Test cases