### PR TITLE
Mapbox content bugfix

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -132,7 +132,7 @@ function generateLayoutInternal(options, callback) {
             if (
                 options.extractMetadata &&
                 options.format &&
-                (img.svg.includes('mapbox-stretch') || img.svg.includes('mapbox-text-placeholder'))
+                (img.svg.includes('mapbox-stretch') || img.svg.includes('mapbox-text-placeholder') || img.svg.includes('mapbox-content'))
             ) {
                 const metaOps = { svg: img.svg, pixelRatio: options.pixelRatio };
                 extractMetadata(metaOps, (err, metadataProps) => {

--- a/test/fixture/svg-metadata/au-national-route-5-only-content.svg
+++ b/test/fixture/svg-metadata/au-national-route-5-only-content.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" id="au-national-route-5" width="38" height="20" viewBox="0 0 38 20">
+  <g>
+    <path d="M0,0 H38 V20 H0 Z" fill="none"/>
+    <path d="M1,3V13a2.951,2.951,0,0,0,2,3c1.632.744,16,3,16,3s14.368-2.256,16-3a2.951,2.951,0,0,0,2-3V3Z" fill="none" stroke="#222222" stroke-linejoin="round" stroke-miterlimit="4px" stroke-width="2"/>
+    <rect id="mapbox-content" x="3" y="7" width="20" height="11" style="fill:none;"/>
+    <path d="M1,3V13a2.951,2.951,0,0,0,2,3c1.632.744,16,3,16,3s14.368-2.256,16-3a2.951,2.951,0,0,0,2-3V3Z" fill="#ffffff"/>
+  </g>
+</svg>

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -373,3 +373,29 @@ test('generateLayout with both placeholder and stretch zone', function (t) {
         t.end();
     });
 });
+
+test('generateLayout with only content', function (t) {
+    var fixtures = [
+        {
+            id: 'au-national-route-5-only-content',
+            svg: fs.readFileSync('./test/fixture/svg-metadata/au-national-route-5-only-content.svg')
+        }
+    ];
+    spritezero.generateLayout({ imgs: fixtures, pixelRatio: 1, format: true }, function (err, formatted) {
+        t.ifError(err);
+        t.deepEqual(
+            formatted,
+            {
+                'au-national-route-5-only-content': {
+                    width: 38,
+                    height: 20,
+                    x: 0,
+                    y: 0,
+                    pixelRatio: 1,
+                    content: [3, 7, 23, 18],
+                }
+            }
+        );
+        t.end();
+    });
+});


### PR DESCRIPTION
This PR fixes an issue where an SVG with a `id="mapbox-content"` node was not having its metadata extracted unless other mapbox nodes existed in the document.