### PR TITLE
Preserve `buffer` in `ImageLayout` if `format: true` is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.3
+#### 2023-05-24
+* Preserve `buffer` in `ImageLayout` if `format: true` is passed
+
 ## 8.0.2
 #### 2022-09-12
 * Updates `svgo` dependency to 2.8.0

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -140,6 +140,7 @@ function generateLayoutInternal(options, callback) {
                       ...img,
                       width: image.width(),
                       height: image.height(),
+                      buffer: image,
                       ...metadataProps
                     });
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/spritezero",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "main": "./index.js",
   "description": "small opinionated sprites",
   "author": "Tom MacWright",


### PR DESCRIPTION
When creating a layout, the `buffer` value for the rendered SVGs was lost if `format: true` was passed, preventing the usage of the formatted layout for rendering. This PR fixes this issue.